### PR TITLE
Adding two missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 google-generativeai
 absl-py
 ollama
+openai
+anthropic


### PR DESCRIPTION
I received two different errors when attempting to run the main script the first time:

```
Traceback (most recent call last):
  File "/home/nick/Documents/research//Deobfuscate-android-app/androidmeda.py", line 14, in <module>
    import openai
ModuleNotFoundError: No module named 'openai'
```
and
```
Traceback (most recent call last):
  File "/home/nick/Documents/research/Deobfuscate-android-app/androidmeda.py", line 15, in <module>
    import anthropic
ModuleNotFoundError: No module named 'anthropic'
```

This pull request adds the two dependencies to the `requirements.txt` file.